### PR TITLE
[codex] Adiciona navegação cruzada aos manuais

### DIFF
--- a/assets/knowledge-theme-2026.css
+++ b/assets/knowledge-theme-2026.css
@@ -430,6 +430,72 @@ body.knowledge-page .chapter-subsection h4 {
     color: var(--kc-blue-900);
 }
 
+body.knowledge-page .guided-reading,
+body.knowledge-page .context-callout {
+    background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+    border: 1px solid rgba(216, 226, 239, 0.95);
+    border-left: 6px solid var(--kc-accent);
+    border-radius: var(--kc-radius-lg);
+    box-shadow: var(--kc-shadow-sm);
+    padding: clamp(1.15rem, 2vw, 1.55rem);
+    margin: 1rem 0 1.6rem;
+}
+
+body.knowledge-page .guided-reading h2,
+body.knowledge-page .context-callout h3 {
+    color: var(--kc-blue-900);
+    margin-bottom: 0.45rem;
+    letter-spacing: -0.02em;
+}
+
+body.knowledge-page .guided-reading > p,
+body.knowledge-page .context-callout > p {
+    margin-bottom: 1rem;
+}
+
+body.knowledge-page .guided-steps,
+body.knowledge-page .continuity-links {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.8rem;
+    margin-top: 0.9rem;
+}
+
+body.knowledge-page .guided-step,
+body.knowledge-page .continuity-link {
+    display: block;
+    text-decoration: none;
+    color: var(--kc-text);
+    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid rgba(216, 226, 239, 0.95);
+    border-radius: var(--kc-radius-sm);
+    padding: 0.9rem 1rem;
+    box-shadow: 0 10px 18px rgba(18, 43, 78, 0.05);
+    transition: transform 0.22s ease, border-color 0.22s ease, box-shadow 0.22s ease;
+}
+
+body.knowledge-page .guided-step:hover,
+body.knowledge-page .continuity-link:hover {
+    transform: translateY(-2px);
+    border-color: var(--kc-blue-500);
+    box-shadow: 0 14px 26px rgba(18, 43, 78, 0.1);
+}
+
+body.knowledge-page .guided-step strong,
+body.knowledge-page .continuity-link strong {
+    display: block;
+    color: var(--kc-blue-900);
+    margin-bottom: 0.25rem;
+}
+
+body.knowledge-page .guided-step span,
+body.knowledge-page .continuity-link span {
+    display: block;
+    color: var(--kc-text-soft);
+    font-size: 0.92rem;
+    line-height: 1.45;
+}
+
 body.knowledge-page p,
 body.knowledge-page li,
 body.knowledge-page td,
@@ -596,5 +662,10 @@ body.knowledge-page--transport {
     body.knowledge-page .nav a {
         width: 100%;
         justify-content: flex-start;
+    }
+
+    body.knowledge-page .guided-steps,
+    body.knowledge-page .continuity-links {
+        grid-template-columns: 1fr;
     }
 }

--- a/compliance-transportadoras.html
+++ b/compliance-transportadoras.html
@@ -405,8 +405,32 @@
             <!-- Alerta -->
             <div class="content-block warning">
                 <div class="block-title">⚠️ Alerta de calendário e integração</div>
-                <p>Em 2026, a operação das transportadoras passou a exigir leitura conjunta de <strong>ICMS</strong>, <strong>ANTT</strong>, <strong>seguros obrigatórios</strong> e <strong>DF-e da reforma</strong>. Em Goiás, no recorte operacional mais comum, o vencimento do ICMS do período continua concentrado no <strong>dia 20</strong>, sem dispensar a leitura das hipóteses especiais; no plano regulatório, o pacote de integração entre <strong>CIOT, PEF e MDF-e</strong> entrou em produção em <strong>14 de julho de 2026</strong>.</p>
+                <p>Em 2026, a operação das transportadoras passou a exigir leitura conjunta de <strong>ICMS</strong>, <strong>ANTT</strong>, <strong>seguros obrigatórios</strong> e <strong>DF-e da reforma</strong>. Em Goiás, no recorte operacional mais comum, o vencimento do ICMS do período continua concentrado no <strong>dia 20</strong>, sem dispensar a leitura das hipóteses especiais.</p>
+                <p><strong>Atualização ANTT de 24/04/2026:</strong> a Portaria SUROC nº 6/2026, com vigência a partir de <strong>24/05/2026</strong>, reforça o CIOT como validação prévia da operação, vincula CIOT ao MDF-e, amplia a exigência para o transporte rodoviário remunerado de cargas e prevê bloqueio quando o frete estiver abaixo do piso mínimo.</p>
             </div>
+
+            <section class="guided-reading" aria-labelledby="trilha-integrada-transporte">
+                <h2 id="trilha-integrada-transporte">Leitura guiada da viagem ao fechamento</h2>
+                <p>Este manual começa na contratação do frete, mas a operação só fecha quando conversa com o DF-e, com o financeiro, com o painel fiscal e com a reforma tributária.</p>
+                <div class="guided-steps">
+                    <a class="guided-step" href="manual-fiscal.html#chapter-7">
+                        <strong>1. Volte ao CT-e</strong>
+                        <span>Tomador, prestação, ICMS e XML precisam estar corretos na origem.</span>
+                    </a>
+                    <a class="guided-step" href="#cap2a">
+                        <strong>2. Decida o ICMS do frete</strong>
+                        <span>UF de início, GNRE, apuração mensal e benefício sem misturar mercadoria.</span>
+                    </a>
+                    <a class="guided-step" href="manual-financeiro.html#m3">
+                        <strong>3. Feche cobrança e pagamento</strong>
+                        <span>Frete contratado, CT-e, título, baixa e comprovante em uma trilha.</span>
+                    </a>
+                    <a class="guided-step" href="painel-fiscal/index.html#reforma">
+                        <strong>4. Prepare a transição 2026</strong>
+                        <span>Campos novos, split payment preparatório, cClassTrib e contratos.</span>
+                    </a>
+                </div>
+            </section>
 
             <!-- Objetivo -->
             <section class="section">
@@ -698,6 +722,25 @@
                                 <li>Se <strong>inscrita</strong> (ex.: GO): recolher por <strong>apuração mensal</strong> e garantir escrituração correta do CT-e (<strong>Bloco D</strong>).</li>
                             </ul>
                         </div>
+
+                        <div class="context-callout">
+                            <h3>Continue no documento e na alíquota</h3>
+                            <p>Depois de decidir a UF competente, volte ao CT-e e consulte a alíquota/benefício aplicável antes de liberar o faturamento.</p>
+                            <div class="continuity-links">
+                                <a class="continuity-link" href="manual-fiscal.html#chapter-7">
+                                    <strong>Manual fiscal: CT-e</strong>
+                                    <span>Revise tomador, campos essenciais e crédito do frete.</span>
+                                </a>
+                                <a class="continuity-link" href="painel-fiscal/index.html#aliquotas">
+                                    <strong>Painel: alíquotas ICMS</strong>
+                                    <span>Use a tabela como conferência da rota e da UF.</span>
+                                </a>
+                                <a class="continuity-link" href="painel-fiscal/index.html#icmsgo">
+                                    <strong>Painel: ICMS/GO</strong>
+                                    <span>Separe benefício da mercadoria e benefício do serviço.</span>
+                                </a>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="chapter">
@@ -829,6 +872,25 @@
                                 <li><strong>CIOT ou vale-pedágio mal tratados</strong>: abrem risco regulatório e contaminam a contratação inteira.</li>
                                 <li><strong>Subcontratação mal documentada</strong>: desorganiza sujeito passivo, cobrança e PIS/Cofins.</li>
                             </ul>
+                        </div>
+
+                        <div class="context-callout">
+                            <h3>Da viagem para a cobrança</h3>
+                            <p>Se a cadeia documental não estiver inteira, a transportadora pode até emitir, mas perde força para cobrar, creditar ou defender a operação.</p>
+                            <div class="continuity-links">
+                                <a class="continuity-link" href="manual-fiscal.html#chapter-8">
+                                    <strong>MDF-e e encerramento</strong>
+                                    <span>Confira o ciclo da viagem e os eventos obrigatórios.</span>
+                                </a>
+                                <a class="continuity-link" href="manual-financeiro.html#m3">
+                                    <strong>Fiscal x financeiro</strong>
+                                    <span>Leve CT-e, título, baixa e comprovante para a mesma trilha.</span>
+                                </a>
+                                <a class="continuity-link" href="manual-financeiro.html#m5">
+                                    <strong>Contas a receber</strong>
+                                    <span>Cobrança sem prova documental vira disputa comercial.</span>
+                                </a>
+                            </div>
                         </div>
                     </div>
 
@@ -1049,6 +1111,12 @@
                             <p class="text-justify">A reforma do consumo deixou de ser tema te&oacute;rico. Em <strong>2026</strong>, os documentos fiscais entram em <strong>fase de conviv&ecirc;ncia e teste</strong> com os novos campos de <strong>CBS, IBS e Imposto Seletivo</strong>, e isso j&aacute; altera a forma como a transportadora precisa parametrizar CT-e, revisar contrato, organizar cadastros e preparar a trilha de cr&eacute;dito do tomador.</p>
                         </div>
 
+                        <div class="content-block warning">
+                            <div class="block-title">Atualização oficial relevante em 2026</div>
+                            <p>O Portal do CT-e publicou a <strong>NT CT-e 2026.001 v.1.01</strong> informando que os campos ligados a split payment em CT-e/BP-e têm caráter preparatório no ambiente de produção das empresas em 2026. A obrigatoriedade efetiva de preenchimento ou uso dependerá de ato regulatório conjunto do CGIBS e da RFB.</p>
+                            <p>Em paralelo, a ANTT publicou em <strong>24/04/2026</strong> a <strong>Portaria SUROC nº 6/2026</strong>, com vigência em <strong>24/05/2026</strong>, reforçando o vínculo entre CIOT e MDF-e e bloqueio preventivo de frete abaixo do piso mínimo. Essa atualização deve entrar no checklist de contratação antes da viagem.</p>
+                        </div>
+
                         <div class="chapter-subsection">
                             <h4>Onde a leitura costuma errar</h4>
                             <p class="text-justify">O erro &eacute; imaginar que a reforma vai afetar a transportadora apenas quando o novo tributo substituir totalmente o ICMS e o PIS/Cofins. O setor j&aacute; foi puxado para dentro da mudan&ccedil;a porque a qualidade do <strong>CT-e</strong>, a defini&ccedil;&atilde;o do <strong>tomador</strong>, o contrato de frete e a integra&ccedil;&atilde;o entre documento e pagamento pesam na trilha de cr&eacute;dito do cliente.</p>
@@ -1078,6 +1146,26 @@
                             <div class="block-title">Fechamento operacional</div>
                             <p>O cliente embarcador vai cobrar cada vez mais <strong>qualidade documental</strong>, porque cr&eacute;dito ruim vira custo para ele. Quem entregar CT-e limpo, contrato bem redigido, tomador correto e trilha &iacute;ntegra sai na frente na negocia&ccedil;&atilde;o comercial e tamb&eacute;m reduz contencioso.</p>
                         </div>
+
+                        <div class="context-callout">
+                            <h3>Reforma no transporte não termina no CT-e</h3>
+                            <p>Depois de ajustar o documento, confirme a classificação tributária e o efeito financeiro/contratual da transição.</p>
+                            <div class="continuity-links">
+                                <a class="continuity-link" href="painel-fiscal/index.html#reforma">
+                                    <strong>Painel fiscal: reforma</strong>
+                                    <span>Consulte cClassTrib, fontes oficiais e split payment.</span>
+                                </a>
+                                <a class="continuity-link" href="manual-fiscal.html#chapter-18">
+                                    <strong>Manual fiscal: virada 2026</strong>
+                                    <span>Veja como os novos campos entram na rotina dos DF-e.</span>
+                                </a>
+                                <a class="continuity-link" href="manual-financeiro.html#m10">
+                                    <strong>Preço e contrato</strong>
+                                    <span>Atualize margem, frete, crédito e cláusulas comerciais.</span>
+                                </a>
+                            </div>
+                        </div>
+
                     </div>
                 </div>
             </section>
@@ -1196,6 +1284,21 @@
                                 </table>
                             </div>
                         </div>
+
+                        <div class="context-callout">
+                            <h3>Auditoria mensal precisa fechar com gestão</h3>
+                            <p>O checklist de frete alimenta o fechamento financeiro, fiscal e documental. Use-o como ponte para evitar que a evidência fique presa só na operação.</p>
+                            <div class="continuity-links">
+                                <a class="continuity-link" href="manual-financeiro.html#m13">
+                                    <strong>Fechamento D+3</strong>
+                                    <span>Leve CT-e, MDF-e, CIOT, seguro e guias para o relatório.</span>
+                                </a>
+                                <a class="continuity-link" href="guia-dp-rh.html#governanca">
+                                    <strong>Governança documental</strong>
+                                    <span>Aplique a mesma lógica de prova pronta ao DP.</span>
+                                </a>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </section>
@@ -1225,6 +1328,24 @@
             const scrollPercent = (window.scrollY / (document.body.scrollHeight - window.innerHeight)) * 100;
             currentPage = Math.max(1, Math.min(totalPages, Math.ceil((scrollPercent / 100) * totalPages)));
             updatePageNumber();
+        });
+
+        // Navegação suave apenas para âncoras internas
+        document.querySelectorAll('.nav-link').forEach(link => {
+            link.addEventListener('click', function(e) {
+                const targetId = this.getAttribute('href');
+                if (!targetId || !targetId.startsWith('#')) {
+                    return;
+                }
+                e.preventDefault();
+                const targetElement = document.querySelector(targetId);
+                if (targetElement) {
+                    targetElement.scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'start'
+                    });
+                }
+            });
         });
 
         // Destacar seção ativa na navegação

--- a/guia-dp-rh.html
+++ b/guia-dp-rh.html
@@ -361,6 +361,29 @@
 
         <!-- Conteúdo principal -->
         <main class="content">
+            <section class="guided-reading" aria-labelledby="trilha-integrada-dp">
+                <h2 id="trilha-integrada-dp">Leitura guiada do DP dentro do fechamento empresarial</h2>
+                <p>O DP fecha pessoas, encargos e prova trabalhista. Quando essa rotina toca caixa, impostos, retenções ou governança documental, avance pelos materiais abaixo para não deixar passivo escondido no mês.</p>
+                <div class="guided-steps">
+                    <a class="guided-step" href="#fechamento-2026">
+                        <strong>1. Feche folha e obrigações</strong>
+                        <span>eSocial, Reinf, FGTS Digital, DARF e DCTFWeb no calendário correto.</span>
+                    </a>
+                    <a class="guided-step" href="manual-financeiro.html#m8a">
+                        <strong>2. Transforme em provisão</strong>
+                        <span>Folha, férias, 13º e encargos precisam entrar no caixa projetado.</span>
+                    </a>
+                    <a class="guided-step" href="manual-fiscal.html#chapter-15">
+                        <strong>3. Concilie com fiscal</strong>
+                        <span>Retenções, Reinf e escrituração precisam fechar com o mês fiscal.</span>
+                    </a>
+                    <a class="guided-step" href="compliance-transportadoras.html#comparativo">
+                        <strong>4. Use governança comum</strong>
+                        <span>Arquivo, prova e auditoria interna seguem a mesma lógica do compliance.</span>
+                    </a>
+                </div>
+            </section>
+
             <section class="section">
                 <div class="content-block important">
                     <div class="block-title">Como usar este guia</div>
@@ -523,6 +546,25 @@
                         <li><strong>Emitir guias e aprovar financeiramente</strong> antes do vencimento.</li>
                         <li><strong>Transmitir a DCTFWeb e arquivar a trilha do mês</strong>.</li>
                     </ol>
+
+                    <div class="context-callout">
+                        <h3>Depois da folha, continue no caixa e no SPED</h3>
+                        <p>O fechamento de DP vira risco quando não entra no fluxo financeiro ou quando as retenções não conversam com fiscal.</p>
+                        <div class="continuity-links">
+                            <a class="continuity-link" href="manual-financeiro.html#m8a">
+                                <strong>Provisões e NCG</strong>
+                                <span>Leve folha, férias, 13º e encargos para o caixa projetado.</span>
+                            </a>
+                            <a class="continuity-link" href="manual-financeiro.html#m13">
+                                <strong>Fechamento D+3</strong>
+                                <span>Inclua guias e folha no fechamento gerencial do mês.</span>
+                            </a>
+                            <a class="continuity-link" href="manual-fiscal.html#chapter-15">
+                                <strong>Conciliação fiscal</strong>
+                                <span>Retenções, Reinf e obrigações precisam bater com a escrituração.</span>
+                            </a>
+                        </div>
+                    </div>
                 </div>
             </section>
 
@@ -548,6 +590,21 @@
                     <div class="content-block success">
                         <div class="block-title">O que precisa ser provado</div>
                         <p>Pol&iacute;tica interna, base legal, rubrica correta, contrato ou instrumento coletivo, recibo e reflexo coerente na folha, no eSocial e na contabilidade. Quando a prova n&atilde;o fecha, a verba vira discuss&atilde;o sobre natureza salarial.</p>
+                    </div>
+
+                    <div class="context-callout">
+                        <h3>Remuneração também é decisão de caixa</h3>
+                        <p>Antes de criar verba, benefício ou política nova, simule reflexo em folha, encargos, provisões e margem.</p>
+                        <div class="continuity-links">
+                            <a class="continuity-link" href="manual-financeiro.html#m8a">
+                                <strong>Provisões financeiras</strong>
+                                <span>Leve o impacto da remuneração para caixa, NCG e alertas.</span>
+                            </a>
+                            <a class="continuity-link" href="manual-financeiro.html#m13">
+                                <strong>Fechamento gerencial</strong>
+                                <span>Mostre variações de folha como desvio explicado, não surpresa.</span>
+                            </a>
+                        </div>
                     </div>
                 </div>
             </section>
@@ -640,6 +697,21 @@
                         <div class="block-title">Leitura operacional</div>
                         <p>O melhor DP n&atilde;o &eacute; o que corre atr&aacute;s do prazo no &uacute;ltimo dia. &Eacute; o que fecha o m&ecirc;s com <strong>cadastro limpo</strong>, <strong>evento &iacute;ntegro</strong>, <strong>guia correta</strong> e <strong>prova pronta</strong>.</p>
                     </div>
+
+                    <div class="context-callout">
+                        <h3>Governança de DP conversa com compliance</h3>
+                        <p>Arquivo trabalhista, fiscal e operacional têm a mesma finalidade: provar a decisão antes que ela vire defesa.</p>
+                        <div class="continuity-links">
+                            <a class="continuity-link" href="compliance-transportadoras.html#comparativo">
+                                <strong>Checklist de auditoria</strong>
+                                <span>Use a lógica de evidência mínima para revisar também o DP.</span>
+                            </a>
+                            <a class="continuity-link" href="manual-fiscal.html#chapter-16">
+                                <strong>POPs fiscais</strong>
+                                <span>Padronize checklist, responsável, prova e revisão mensal.</span>
+                            </a>
+                        </div>
+                    </div>
                 </div>
             </section>
 
@@ -716,6 +788,24 @@ Assinaturas: ________________________ (Empregador) e ________________________ (E
             const scrollPercent = (window.scrollY / (document.body.scrollHeight - window.innerHeight)) * 100;
             currentPage = Math.max(1, Math.min(totalPages, Math.ceil((scrollPercent / 100) * totalPages)));
             updatePageNumber();
+        });
+
+        // Navegação suave apenas para âncoras internas
+        document.querySelectorAll('.nav-link').forEach(link => {
+            link.addEventListener('click', function(e) {
+                const targetId = this.getAttribute('href');
+                if (!targetId || !targetId.startsWith('#')) {
+                    return;
+                }
+                e.preventDefault();
+                const targetElement = document.querySelector(targetId);
+                if (targetElement) {
+                    targetElement.scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'start'
+                    });
+                }
+            });
         });
 
         // Destacar seção ativa na navegação

--- a/manual-financeiro.html
+++ b/manual-financeiro.html
@@ -607,6 +607,29 @@
 
         <!-- Conteúdo principal -->
         <main class="content">
+            <section class="guided-reading" aria-labelledby="trilha-integrada-financeiro">
+                <h2 id="trilha-integrada-financeiro">Leitura guiada do financeiro para os outros manuais</h2>
+                <p>Use este manual para transformar documento em decisão. Sempre que a rotina financeira depender de imposto, folha, frete ou crédito, avance para o material correlato antes de fechar caixa, margem ou relatório.</p>
+                <div class="guided-steps">
+                    <a class="guided-step" href="#m3">
+                        <strong>1. Integre nota e título</strong>
+                        <span>Pedido, XML, retenção, vencimento, baixa e comprovante em uma linha.</span>
+                    </a>
+                    <a class="guided-step" href="manual-fiscal.html#chapter-15">
+                        <strong>2. Volte ao SPED</strong>
+                        <span>O financeiro só fecha bem quando o XML e a escrituração não divergem.</span>
+                    </a>
+                    <a class="guided-step" href="guia-dp-rh.html#fechamento-2026">
+                        <strong>3. Traga folha e encargos</strong>
+                        <span>Provisões, salários, FGTS Digital e DARF previdenciário afetam o caixa.</span>
+                    </a>
+                    <a class="guided-step" href="painel-fiscal/index.html#reforma">
+                        <strong>4. Reprecifique a transição</strong>
+                        <span>Reforma, crédito e split payment mudam contrato, margem e cobrança.</span>
+                    </a>
+                </div>
+            </section>
+
             <section id="leitura-2026" class="section">
                 <div class="content-block important">
                     <div class="block-title">Leitura 2026</div>
@@ -938,6 +961,25 @@ Receber NF Fornecedor → Conferência (pedido x NF) → Aprovação por alçada
                             <div class="content-block success">
                                 <div class="block-title">O que precisa ser provado</div>
                                 <p>Pedido, contrato, NF, XML, reten&ccedil;&otilde;es, t&iacute;tulo financeiro, comprovante de pagamento e concilia&ccedil;&atilde;o banc&aacute;ria precisam fechar em uma mesma linha de evid&ecirc;ncia. Sem essa trilha, o problema parece financeiro em um dia e fiscal no outro.</p>
+                            </div>
+
+                            <div class="context-callout">
+                                <h3>Continue a integração no fiscal</h3>
+                                <p>Quando a nota cria título ou o pagamento depende de retenção, a conferência precisa voltar para o XML, para o SPED e para o painel de códigos.</p>
+                                <div class="continuity-links">
+                                    <a class="continuity-link" href="manual-fiscal.html#chapter-15">
+                                        <strong>Conciliação com SPED</strong>
+                                        <span>Confira se XML, EFD e financeiro contam a mesma operação.</span>
+                                    </a>
+                                    <a class="continuity-link" href="painel-fiscal/index.html#cfop">
+                                        <strong>CFOP, CST e cBenef</strong>
+                                        <span>Valide a parametrização antes de virar cobrança ou pagamento.</span>
+                                    </a>
+                                    <a class="continuity-link" href="compliance-transportadoras.html#regimes">
+                                        <strong>Frete e faturamento</strong>
+                                        <span>Se houver CT-e/MDF-e, inclua tomador, CIOT e seguro na prova.</span>
+                                    </a>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -1380,6 +1422,21 @@ Compra/Estoque → Venda → Contas a Receber (PMR) → Caixa → Contas a Pagar
                                 <p>Receita 1,0 mi; CMV 0,6 mi; CR 0,5 mi → <strong>PMR 15d</strong>; Fornec. 0,3 mi → <strong>PMP 15d</strong>; Estoque 0,8 mi → <strong>DIO 40d</strong>; <strong>CCC 40d</strong>; <strong>NCG ≈ 1,0 mi</strong>.</p>
                                 <p>Quero reduzir NCG 250k → <strong>cortar DIO ~10d</strong> (compra fina/queima) <strong>ou aumentar PMP ~10d</strong>.</p>
                             </div>
+
+                            <div class="context-callout">
+                                <h3>Provisão pede ponte com DP e fiscal</h3>
+                                <p>Folha, férias, 13º, tributos e contingências não são envelopes soltos: eles precisam nascer do fechamento operacional e voltar para o fluxo de caixa.</p>
+                                <div class="continuity-links">
+                                    <a class="continuity-link" href="guia-dp-rh.html#fechamento-2026">
+                                        <strong>Fechamento mensal DP</strong>
+                                        <span>Transforme folha, eSocial, Reinf e guias em números provisionados.</span>
+                                    </a>
+                                    <a class="continuity-link" href="manual-fiscal.html#chapter-15">
+                                        <strong>SPED e XML</strong>
+                                        <span>Tributos provisionados precisam conversar com a escrituração.</span>
+                                    </a>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -1494,6 +1551,25 @@ Compra/Estoque → Venda → Contas a Receber (PMR) → Caixa → Contas a Pagar
                                 <p><strong>Fórmula básica:</strong> Preço = (Custo + Despesas + Margem) / (1 - % Impostos)</p>
                                 <p><strong>Markup:</strong> Multiplicador sobre o custo para chegar ao preço final</p>
                                 <p><strong>Margem de Contribuição:</strong> (Preço - Custos Variáveis) / Preço</p>
+                            </div>
+
+                            <div class="context-callout">
+                                <h3>Preço sem classificação fiscal fica cego</h3>
+                                <p>Antes de congelar margem, confirme o efeito de NCM, PIS/Cofins, ICMS, frete e reforma. O custo recuperável muda a leitura do preço.</p>
+                                <div class="continuity-links">
+                                    <a class="continuity-link" href="painel-fiscal/index.html#ncm">
+                                        <strong>NCM x PIS/Cofins</strong>
+                                        <span>Revise monofásicos, alíquota zero, crédito e regime federal.</span>
+                                    </a>
+                                    <a class="continuity-link" href="painel-fiscal/index.html#icmsgo">
+                                        <strong>ICMS/GO e benefícios</strong>
+                                        <span>Confirme se o benefício altera custo, preço ou prova documental.</span>
+                                    </a>
+                                    <a class="continuity-link" href="manual-fiscal.html#chapter-11">
+                                        <strong>Impostos na prática</strong>
+                                        <span>Volte ao cálculo de ST, DIFAL e desoneração antes da decisão.</span>
+                                    </a>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -1664,6 +1740,25 @@ Compra/Estoque → Venda → Contas a Receber (PMR) → Caixa → Contas a Pagar
                                     <li><strong>Aging CR/CP:</strong> Posição de recebíveis e pagamentos</li>
                                     <li><strong>Análise de Desvios:</strong> Orçado vs realizado com explicações</li>
                                 </ol>
+                            </div>
+
+                            <div class="context-callout">
+                                <h3>Fechamento gerencial precisa de lastro operacional</h3>
+                                <p>O D+3 só é confiável quando fiscal, DP e financeiro encerram o mesmo mês, com os mesmos fatos e evidências.</p>
+                                <div class="continuity-links">
+                                    <a class="continuity-link" href="manual-fiscal.html#chapter-15">
+                                        <strong>SPED e XML</strong>
+                                        <span>Use a escrituração como referência para receita, compra e imposto.</span>
+                                    </a>
+                                    <a class="continuity-link" href="guia-dp-rh.html#fechamento-2026">
+                                        <strong>Folha e encargos</strong>
+                                        <span>Inclua salários, FGTS Digital, DARF e DCTFWeb no calendário.</span>
+                                    </a>
+                                    <a class="continuity-link" href="compliance-transportadoras.html#comparativo">
+                                        <strong>Auditoria do frete</strong>
+                                        <span>Para transportadoras, CT-e, MDF-e e CIOT entram no fechamento.</span>
+                                    </a>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -2202,8 +2297,11 @@ End Sub
         // Script para navegação suave
         document.querySelectorAll('.nav-link, .toc a').forEach(link => {
             link.addEventListener('click', function(e) {
-                e.preventDefault();
                 const targetId = this.getAttribute('href');
+                if (!targetId || !targetId.startsWith('#')) {
+                    return;
+                }
+                e.preventDefault();
                 const targetElement = document.querySelector(targetId);
                 if (targetElement) {
                     targetElement.scrollIntoView({

--- a/manual-fiscal.html
+++ b/manual-fiscal.html
@@ -493,6 +493,29 @@
         <!-- Content -->
         <main class="content">
 
+            <section class="guided-reading" aria-labelledby="trilha-integrada-fiscal">
+                <h2 id="trilha-integrada-fiscal">Leitura guiada entre fiscal, painel e operação</h2>
+                <p>Use este manual como eixo técnico dos DF-e. Quando a leitura sair do XML e tocar cálculo, caixa, folha ou transporte, siga a continuidade indicada abaixo para fechar a operação com prova documental.</p>
+                <div class="guided-steps">
+                    <a class="guided-step" href="#chapter-10">
+                        <strong>1. Classifique a operação</strong>
+                        <span>NCM, CFOP, CST/CSOSN e cBenef antes de calcular imposto.</span>
+                    </a>
+                    <a class="guided-step" href="painel-fiscal/index.html#cfop">
+                        <strong>2. Consulte o painel fiscal</strong>
+                        <span>Use as abas de CFOP, CST, NCM, ICMS/GO, cBenef e reforma como apoio vivo.</span>
+                    </a>
+                    <a class="guided-step" href="manual-financeiro.html#m3">
+                        <strong>3. Feche o reflexo financeiro</strong>
+                        <span>Título, baixa, retenção, comprovante e conciliação precisam contar a mesma história.</span>
+                    </a>
+                    <a class="guided-step" href="compliance-transportadoras.html#regimes">
+                        <strong>4. Se houver frete, vá para transporte</strong>
+                        <span>CT-e, MDF-e, CIOT, tomador e crédito exigem leitura própria.</span>
+                    </a>
+                </div>
+            </section>
+
 
             <!-- Sumário -->
             <section id="sumario" class="toc">
@@ -1539,6 +1562,29 @@
             <p>Em leitura conservadora, a compra de <strong>veículo operacional</strong> com suporte em crédito de ICMS tem base muito mais sólida do que a aquisição de <strong>automóvel de uso administrativo</strong>. E o ponto decisivo é este: <strong>crédito escritural não é moeda livre</strong>. Ele precisa estar encaixado na hipótese legal correta.</p>
             <p><strong>Base oficial para consulta:</strong> <a href="https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp87.htm" target="_blank">LC 87/1996</a>, <a href="https://appasp.economia.go.gov.br/legislacao/arquivos/Cte/CTE.htm" target="_blank">CTE/RCTE de Goiás</a> e <a href="https://appasp.economia.go.gov.br/legislacao/arquivos/Secretario/IN/IN_0715_2005.htm" target="_blank">IN 715/2005-GSF</a>.</p>
         </div>
+
+        <div class="context-callout">
+            <h3>Se o assunto é transporte, continue fora daqui</h3>
+            <p>Este capítulo explica o CT-e dentro da lógica dos DF-e. Para decidir ICMS do frete, CIOT, MDF-e, contrato, seguro, crédito e cobrança, a leitura precisa continuar no material de transportadoras e no painel fiscal.</p>
+            <div class="continuity-links">
+                <a class="continuity-link" href="compliance-transportadoras.html#fundamentos">
+                    <strong>ICMS do frete e GNRE</strong>
+                    <span>Defina UF de início, tomador e forma de recolhimento.</span>
+                </a>
+                <a class="continuity-link" href="compliance-transportadoras.html#regimes">
+                    <strong>Cadeia documental da viagem</strong>
+                    <span>CT-e, MDF-e, CIOT, seguro e faturamento no mesmo roteiro.</span>
+                </a>
+                <a class="continuity-link" href="painel-fiscal/index.html#aliquotas">
+                    <strong>Alíquotas e ICMS/GO</strong>
+                    <span>Use as tabelas do painel para validar a rota e o benefício.</span>
+                </a>
+                <a class="continuity-link" href="manual-financeiro.html#m3">
+                    <strong>Reflexo financeiro</strong>
+                    <span>Frete negociado, título, baixa e comprovante precisam fechar.</span>
+                </a>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -1758,6 +1804,29 @@
                 <li><strong>CSOSN (Código de Situação da Operação no Simples Nacional):</strong> Usado por empresas do Simples Nacional. Ex: 101 (Tributada com permissão de crédito), 102 (Tributada sem permissão de crédito), 500 (ICMS cobrado anteriormente por ST).</li>
             </ul>
             <p>A escolha do CST/CSOSN correto é o que define quais campos de base de cálculo e alíquota de ICMS deverão ser preenchidos no XML.</p>
+        </div>
+
+        <div class="context-callout">
+            <h3>Continuidade natural deste capítulo</h3>
+            <p>Quando a dúvida sair da definição conceitual e virar parametrização concreta, use o painel como mesa de conferência antes de emitir ou escriturar.</p>
+            <div class="continuity-links">
+                <a class="continuity-link" href="painel-fiscal/index.html#cfop">
+                    <strong>CFOP e natureza da operação</strong>
+                    <span>Confirme entrada, saída, UF e finalidade antes do XML.</span>
+                </a>
+                <a class="continuity-link" href="painel-fiscal/index.html#cst">
+                    <strong>CST/CSOSN</strong>
+                    <span>Amarre regime, tributação e campos obrigatórios.</span>
+                </a>
+                <a class="continuity-link" href="painel-fiscal/index.html#ncm">
+                    <strong>NCM e PIS/Cofins</strong>
+                    <span>Revise classificação e reflexo federal por item.</span>
+                </a>
+                <a class="continuity-link" href="painel-fiscal/index.html#cbenef">
+                    <strong>cBenef Goiás</strong>
+                    <span>Use somente código com benefício vigente e prova documental.</span>
+                </a>
+            </div>
         </div>
     </div>
 </div>
@@ -2126,6 +2195,25 @@
             <h3>✅ Dica de Estudo</h3>
             <p>Aprenda a ler o arquivo .txt do SPED. Abra-o em um editor de texto e familiarize-se com os principais registros (C100, C170, C190, 0200 - Tabela de Itens). Ser capaz de localizar uma nota ou um produto diretamente no arquivo de texto é uma habilidade avançada que pode economizar horas na resolução de problemas de validação.</p>
         </div>
+
+        <div class="context-callout">
+            <h3>Depois do SPED, feche caixa e folha</h3>
+            <p>A conciliação fiscal só fica madura quando conversa com o fechamento financeiro e, quando houver folha ou retenções, com o fechamento de DP.</p>
+            <div class="continuity-links">
+                <a class="continuity-link" href="manual-financeiro.html#m13">
+                    <strong>Fechamento D+3</strong>
+                    <span>Transforme XML, títulos e conciliação em rotina gerencial.</span>
+                </a>
+                <a class="continuity-link" href="manual-financeiro.html#m3">
+                    <strong>Integração fiscal-financeiro</strong>
+                    <span>Confira a trilha pedido, nota, título, baixa e comprovante.</span>
+                </a>
+                <a class="continuity-link" href="guia-dp-rh.html#fechamento-2026">
+                    <strong>Fechamento DP 2026</strong>
+                    <span>eSocial, Reinf, DCTFWeb e guias precisam bater com o mês.</span>
+                </a>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -2234,6 +2322,12 @@
                         <p>Em 2026, a reforma tributária deixou de ser só pauta de seminário e passou a mexer no coração da rotina fiscal: <strong>cadastro</strong>, <strong>XML</strong>, <strong>ERP</strong>, <strong>homologação</strong>, <strong>regras de negócio</strong> e <strong>qualidade documental</strong>. Este capítulo trata do que já está em produção e do que precisa ser testado com método para a empresa não descobrir a mudança pela rejeição, pela perda de crédito ou pelo retrabalho no fechamento.</p>
                     </div>
 
+                    <div class="content-block warning">
+                        <div class="block-title">Atualização tributária checada em 25/04/2026</div>
+                        <p>As fontes oficiais mais recentes mantêm 2026 como ano de adaptação e teste, mas com obrigações acessórias reais nos DF-e. Para NF-e/NFC-e, a referência vigente de leiaute da reforma é a <strong>NT 2025.002 v.1.35</strong>, acompanhada do <strong>Informe Técnico 2025.002 v.1.50</strong> e da tabela <strong>cClassTrib</strong> publicada em <strong>15/04/2026</strong>. Também entram na rotina a tabela de meios de pagamento de <strong>06/03/2026</strong> e a tabela de NCM/uTrib vigente desde <strong>01/02/2026</strong>.</p>
+                        <p>No transporte, a leitura de 2026 deve observar também a <strong>NT CT-e 2026.001 v.1.01</strong>: os campos de split payment em CT-e/BP-e têm caráter preparatório em 2026, sem exigência de uso em produção até novo ato conjunto do CGIBS e da RFB.</p>
+                    </div>
+
                     <div class="content-block">
                         <h2>1. CRT=4 (MEI) - Já em Vigor</h2>
                         <ul>
@@ -2272,7 +2366,7 @@
                         <p>O erro mais comum &eacute; tratar 2026 como “ano de espera”. N&atilde;o &eacute;. O ano j&aacute; exige <strong>preparo documental</strong>, <strong>homologa&ccedil;&atilde;o de sistema</strong>, <strong>revis&atilde;o de cadastros</strong> e <strong>governan&ccedil;a do XML</strong>. Quem deixa isso para a &uacute;ltima hora tende a descobrir o problema na rejei&ccedil;&atilde;o do documento, na perda de cr&eacute;dito do cliente ou no retrabalho do fechamento.</p>
 
                         <h3>Como a regra funciona de verdade</h3>
-                        <p>NF-e, NFC-e, CT-e, CT-e OS, NFCom, NFS-e e outros documentos entram na transi&ccedil;&atilde;o com novos grupos e campos para suportar <strong>CBS, IBS e IS</strong>. A <strong>NT 2025.002</strong> e as orienta&ccedil;&otilde;es oficiais de 2026 tratam isso como trabalho obrigat&oacute;rio de <strong>parametriza&ccedil;&atilde;o, teste e governan&ccedil;a</strong>. Em outras palavras: o documento fiscal passa a carregar mais informa&ccedil;&atilde;o tribut&aacute;ria e precisa refletir com mais fidelidade a opera&ccedil;&atilde;o real.</p>
+                        <p>NF-e, NFC-e, CT-e, CT-e OS, NFCom, NFS-e e outros documentos entram na transi&ccedil;&atilde;o com novos grupos e campos para suportar <strong>CBS, IBS e IS</strong>. A <strong>NT 2025.002 v.1.35</strong> e as orienta&ccedil;&otilde;es oficiais de 2026 tratam isso como trabalho obrigat&oacute;rio de <strong>parametriza&ccedil;&atilde;o, teste e governan&ccedil;a</strong>. Em outras palavras: o documento fiscal passa a carregar mais informa&ccedil;&atilde;o tribut&aacute;ria e precisa refletir com mais fidelidade a opera&ccedil;&atilde;o real.</p>
                         <ul>
                             <li><strong>Novos campos</strong> para base, al&iacute;quota, valor, hip&oacute;teses diferenciadas e informa&ccedil;&otilde;es auxiliares.</li>
                             <li><strong>Novas tabelas</strong> e c&oacute;digos para leitura tribut&aacute;ria da reforma.</li>
@@ -2305,6 +2399,25 @@
                             <li><strong>Integrar fiscal, TI, comercial e jurídico</strong>, porque a reforma não cabe mais só dentro do departamento fiscal.</li>
                         </ul>
                         <p>O profissional que vai se destacar em 2026 n&atilde;o &eacute; o que decorou a reforma. &Eacute; o que consegue transformar a mudan&ccedil;a em <strong>processo, valida&ccedil;&atilde;o e documento correto</strong>. O pr&oacute;ximo cap&iacute;tulo leva esse racioc&iacute;nio para casos pr&aacute;ticos completos.</p>
+                    </div>
+
+                    <div class="context-callout">
+                        <h3>Continue a virada 2026 nos materiais correlatos</h3>
+                        <p>Depois de entender os campos novos, a próxima decisão é onde testar, quem valida e como contrato, pagamento, frete e crédito serão sustentados.</p>
+                        <div class="continuity-links">
+                            <a class="continuity-link" href="painel-fiscal/index.html#reforma">
+                                <strong>Painel fiscal: reforma</strong>
+                                <span>Consulte cClassTrib, fontes oficiais, split payment e contratos.</span>
+                            </a>
+                            <a class="continuity-link" href="compliance-transportadoras.html#implementacao">
+                                <strong>Transportadoras: CT-e 2026</strong>
+                                <span>Leve a reforma para tomador, TMS, CIOT, MDF-e e contrato de frete.</span>
+                            </a>
+                            <a class="continuity-link" href="manual-financeiro.html#m10">
+                                <strong>Preço e margem</strong>
+                                <span>Reveja custo, impostos recuperáveis e cláusulas comerciais.</span>
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -2978,7 +3091,11 @@
                         <ul>
                             <li><strong>NT 2024.001:</strong> Institui o CRT=4 para o MEI.</li>
                             <li><strong>NT 2025.001:</strong> Institui o QR-Code v3.0 para a NFC-e.</li>
-                            <li><strong>NT 2025.002:</strong> Introduz os campos da Reforma Tributária (IBS/CBS/IS) nos leiautes.</li>
+                            <li><strong>NT 2025.002 v.1.35:</strong> Introduz campos e regras de validação da Reforma Tributária (IBS/CBS/IS) na NF-e/NFC-e.</li>
+                            <li><strong>Informe Técnico 2025.002 v.1.50:</strong> Divulga tabela de classificação tributária e indicadores de CST do IBS/CBS.</li>
+                            <li><strong>Informe Técnico 2024.002 v.1.11:</strong> Divulga atualização da tabela de meios de pagamento.</li>
+                            <li><strong>Informe Técnico 2024.001 v.2.30:</strong> Divulga atualização da tabela de NCM vigente a partir de 01/02/2026.</li>
+                            <li><strong>NT CT-e 2026.001 v.1.01:</strong> Trata os campos de split payment em CT-e/BP-e como preparação técnica em 2026, sem exigência de uso em produção até novo ato regulatório.</li>
                             <li><strong>Ato Conjunto RFB/CGIBS 1/2025:</strong> disciplina obrigações acessórias iniciais da reforma do consumo.</li>
                             <li><strong>Orientações 2026 da Reforma do Consumo:</strong> consolidam a fase de implantação assistida e o ambiente de adaptação dos DF-e.</li>
                             <li><strong>NT 2022.005:</strong> Trata das regras de validação do DIFAL.</li>

--- a/painel-fiscal/index.html
+++ b/painel-fiscal/index.html
@@ -395,6 +395,65 @@
       gap: 1rem;
     }
 
+    .guided-reading,
+    .context-callout {
+      background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+      border: 1px solid #dbe5f1;
+      border-left: 6px solid #f97316;
+      border-radius: 12px;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+      padding: 1.5rem;
+      margin-bottom: 2rem;
+    }
+
+    .guided-reading h2,
+    .context-callout h3 {
+      color: #1e3a8a;
+      margin-bottom: 0.5rem;
+    }
+
+    .guided-steps,
+    .continuity-links {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.8rem;
+      margin-top: 1rem;
+    }
+
+    .guided-step,
+    .continuity-link {
+      display: block;
+      text-decoration: none;
+      color: #1e293b;
+      background: #ffffff;
+      border: 1px solid #dbe5f1;
+      border-radius: 10px;
+      padding: 0.9rem 1rem;
+      transition: all 0.3s ease;
+    }
+
+    .guided-step:hover,
+    .continuity-link:hover {
+      border-color: #3b82f6;
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(59, 130, 246, 0.14);
+    }
+
+    .guided-step strong,
+    .continuity-link strong {
+      display: block;
+      color: #1e3a8a;
+      margin-bottom: 0.25rem;
+    }
+
+    .guided-step span,
+    .continuity-link span {
+      display: block;
+      color: #64748b;
+      font-size: 0.92rem;
+      line-height: 1.45;
+    }
+
     /* Footer */
     .footer {
       background: #1e293b;
@@ -524,7 +583,7 @@
 <div class="header-content">
 <div class="logo">Painel Fiscal - Consulta Tributária</div>
 <div class="tagline">Consulta prática com foco em Goiás, PIS/Cofins federal, cBenef, setores críticos e leitura normativa de ponta a ponta</div>
-<div class="subtitle">Conteúdo atualizado em 19/04/2026 para apoiar emissão fiscal, enquadramento documental e leitura integrada de ICMS/GO, PIS/Cofins e reforma tributária</div>
+<div class="subtitle">Conteúdo atualizado em 25/04/2026 para apoiar emissão fiscal, enquadramento documental e leitura integrada de ICMS/GO, PIS/Cofins, transporte e reforma tributária</div>
 </div>
 </header>
 <!-- Container Principal -->
@@ -540,6 +599,28 @@
 <h3>Consulta fiscal para quem precisa decidir</h3>
 <p>Este painel concentra os temas que mais pesam na rotina fiscal e comercial: <strong>cBenef</strong> em Goiás, benefícios e reduções de base do <strong>RCTE</strong>, <strong>PIS/Cofins federal por NCM</strong>, monofásicos, eletrônicos/TIC, veículos, grãos, combustíveis e os efeitos da <strong>reforma tributária</strong> sobre incentivos e documentação. A base foi montada a partir do texto legal e dos materiais oficiais mais recentes, para acelerar a triagem sem perder lastro normativo.</p>
 </div>
+<section class="guided-reading" aria-labelledby="trilha-integrada-painel">
+<h2 id="trilha-integrada-painel">Leitura guiada a partir do painel</h2>
+<p>Use o painel como mesa de consulta viva. Quando a resposta exigir procedimento, fechamento, frete ou folha, continue pelos manuais correlatos em vez de tratar a tabela como fim da análise.</p>
+<div class="guided-steps">
+<a class="guided-step" href="../manual-fiscal.html#chapter-10">
+<strong>1. Volte ao manual fiscal</strong>
+<span>Entenda por que CFOP, CST, NCM e cBenef existem antes de escolher código.</span>
+</a>
+<a class="guided-step" href="../manual-financeiro.html#m10">
+<strong>2. Reflita no preço</strong>
+<span>Imposto recuperável, benefício e frete mudam margem e contrato.</span>
+</a>
+<a class="guided-step" href="../compliance-transportadoras.html#cap2a">
+<strong>3. Separe frete de mercadoria</strong>
+<span>ICMS do transporte, GNRE e tomador pedem leitura própria.</span>
+</a>
+<a class="guided-step" href="../guia-dp-rh.html#fechamento-2026">
+<strong>4. Feche o mês inteiro</strong>
+<span>Folha, retenções e obrigações acessórias precisam entrar na rotina.</span>
+</a>
+</div>
+</section>
 <!-- Navegação -->
 <nav class="nav-tabs">
 <a class="nav-tab active" data-section="guia" href="#guia">
@@ -766,6 +847,20 @@
 <p><strong>Como funciona de verdade:</strong> o CFOP precisa conversar com <strong>origem e destino</strong>, <strong>tipo de operação</strong>, <strong>natureza da mercadoria ou serviço</strong>, <strong>finalidade da nota</strong> e <strong>reflexo tributário</strong>. Um mesmo item pode circular com CFOP diferente conforme devolução, remessa, industrialização, revenda ou transferência.</p>
 <p><strong>Exemplo prático:</strong> uma venda interna de mercadoria adquirida de terceiros costuma seguir a lógica do <strong>5.102</strong>. Se essa mesma mercadoria for devolvida, o CFOP deixa de ser de venda e passa para a lógica da devolução correspondente. O erro não está só no número: ele muda a leitura do XML, da apuração e da escrituração.</p>
 <p><strong>O que precisa ser provado:</strong> pedido, contrato, origem da mercadoria, destino da operação, finalidade do documento e coerência entre CFOP, CST, natureza da operação e escrita fiscal.</p>
+</div>
+<div class="context-callout">
+<h3>Antes de escolher o código, volte ao capítulo de tabelas</h3>
+<p>Se a dúvida envolve CFOP, CST, CSOSN, NCM ou CEST, o painel ajuda na consulta, mas o raciocínio completo está no manual fiscal.</p>
+<div class="continuity-links">
+<a class="continuity-link" href="../manual-fiscal.html#chapter-10">
+<strong>Capítulo 10: tabelas críticas</strong>
+<span>Reveja a lógica de NCM, CEST, CFOP, CST e CSOSN.</span>
+</a>
+<a class="continuity-link" href="../manual-fiscal.html#chapter-11">
+<strong>Capítulo 11: cálculos</strong>
+<span>Leve a classificação para ST, DIFAL e desoneração.</span>
+</a>
+</div>
 </div>
 <div class="table-container">
 <table class="data-table">
@@ -1452,6 +1547,24 @@
 <p>A espinha dorsal da transição passa pela <strong>EC 132/2023</strong>, pela <strong>LC 214/2025</strong> e pela <strong>LC 227/2026</strong>. Em 2026, a reforma já deixou de ser apenas desenho institucional e passou a afetar rotina de <strong>cadastro</strong>, <strong>documento fiscal</strong>, <strong>parametrização sistêmica</strong>, <strong>contrato</strong> e <strong>prova do crédito</strong>.</p>
 <p>O erro mais comum é olhar a reforma apenas como troca futura de tributo. Na prática, a preparação documental, contratual e tecnológica já começou, especialmente para quem depende de incentivos de ICMS, de aproveitamento de crédito pelo adquirente e de integração consistente entre nota e pagamento.</p>
 </div>
+<div class="context-callout">
+<h3>Atualização oficial checada em 25/04/2026</h3>
+<p>O painel passa a considerar a <strong>NT 2025.002 v.1.35</strong> da NF-e/NFC-e, o <strong>Informe Técnico 2025.002 v.1.50</strong> e a tabela <strong>cClassTrib</strong> publicada em <strong>15/04/2026</strong>. Também foram considerados a tabela de meios de pagamento de <strong>06/03/2026</strong>, a NCM/uTrib vigente desde <strong>01/02/2026</strong>, a orientação da Receita sobre 2026 como período de teste/adaptação e a <strong>NT CT-e 2026.001 v.1.01</strong> sobre split payment preparatório em CT-e/BP-e.</p>
+<div class="continuity-links">
+<a class="continuity-link" href="../manual-fiscal.html#chapter-18">
+<strong>Manual fiscal: virada 2026</strong>
+<span>Veja como os novos campos entram na leitura dos DF-e.</span>
+</a>
+<a class="continuity-link" href="../compliance-transportadoras.html#implementacao">
+<strong>Transportadoras: CT-e 2026</strong>
+<span>Leve a atualização para tomador, TMS, CIOT, MDF-e e contrato.</span>
+</a>
+<a class="continuity-link" href="#fontes">
+<strong>Fontes oficiais</strong>
+<span>Abra os portais usados para confirmar versão e vigência.</span>
+</a>
+</div>
+</div>
 <div class="info-box" style="background:#f8fafc;border-color:#cbd5e1;">
 <h3>Como ler 2026 sem antecipar 2033</h3>
 <p>Uma das confusões mais comuns de 2026 é agir como se o sistema antigo já tivesse terminado. Não terminou. O que existe hoje é uma travessia em que a empresa precisa governar <strong>duas linguagens ao mesmo tempo</strong>: a do sistema atual, com <strong>ICMS, cBenef, incentivos estaduais, CST e EFD</strong>, e a do sistema novo, com <strong>IBS, CBS, split payment, documento idôneo e qualidade da informação para crédito</strong>.</p>
@@ -1702,7 +1815,13 @@
 <p><a href="https://www.planalto.gov.br/ccivil_03/Leis/LCP/Lcp214.htm" target="_blank" rel="noopener">LC 214/2025</a></p>
 <p><a href="https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp227.htm" target="_blank" rel="noopener">LC 227/2026</a></p>
 <p><a href="https://www.gov.br/fazenda/pt-br/acesso-a-informacao/acoes-e-programas/reforma-tributaria/arquivos/perguntas-e-respostas-reforma-tributaria_.pdf" target="_blank" rel="noopener">Perguntas e Respostas oficiais</a></p>
-<p><a href="https://www.gov.br/receitafederal/pt-br/assuntos/noticias/2026/abril/reforma-tributaria-receita-federal-esclarece-pontos-sobre-a-operacao-assistida-e-as-obrigacoes-acessorias-no-periodo-de-testes" target="_blank" rel="noopener">Receita Federal - operação assistida e período de testes</a></p>
+<p><a href="https://www.gov.br/receitafederal/pt-br/acesso-a-informacao/acoes-e-programas/programas-e-atividades/reforma-consumo/orientacoes-2026" target="_blank" rel="noopener">Receita Federal - orientações da reforma para 2026</a></p>
+<p><a href="https://www.gov.br/receitafederal/pt-br/assuntos/noticias/2026/abril/reforma-tributaria-receita-federal-desmentem-aplicacao-imediata-de-multas-e-reforcam-transicao-simplificada-em-2026" target="_blank" rel="noopener">Receita Federal - transição simplificada em 2026</a></p>
+<p><a href="https://www.nfe.fazenda.gov.br/portal/listaConteudo.aspx?tipoConteudo=6WfrpZYE4Ik%3D" target="_blank" rel="noopener">NF-e - Notas Técnicas vigentes</a></p>
+<p><a href="https://www.nfe.fazenda.gov.br/portal/listaConteudo.aspx?tipoConteudo=hXzemuyNHW4%3D" target="_blank" rel="noopener">NF-e - Informes Técnicos vigentes</a></p>
+<p><a href="https://www.nfe.fazenda.gov.br/portal/listaConteudo.aspx?tipoConteudo=%2FNJarYc9nus%3D" target="_blank" rel="noopener">NF-e - tabelas diversas, cClassTrib, NCM e meios de pagamento</a></p>
+<p><a href="https://www.cte.fazenda.gov.br/portal/informe.aspx" target="_blank" rel="noopener">CT-e - informes e notas técnicas</a></p>
+<p><a href="https://www.gov.br/antt/pt-br/assuntos/ultimas-noticias/frete-irregular-e-barrado-antes-de-existir-antt-transforma-ciot-em-filtro-obrigatorio-e-reforca-o-cumprimento-do-piso-minimo" target="_blank" rel="noopener">ANTT - Portaria SUROC nº 6/2026 e vínculo CIOT/MDF-e</a></p>
 </div>
 </div>
 </section>
@@ -1723,7 +1842,7 @@
 <p class="logo-footer">RJC ASSESSORIA</p>
 <p>A Arte de Registrar o Patrimônio</p>
 <p>contato@rjcassessoria.com.br | (62) 8168-0949</p>
-<p>© 2026 RJC Assessoria - Painel Fiscal | organização editorial V3 atualizada em 19/04/2026</p>
+<p>© 2026 RJC Assessoria - Painel Fiscal | organização editorial V3 atualizada em 25/04/2026</p>
 </div>
 </footer>
 <script>
@@ -2594,11 +2713,8 @@
       setupEventListeners();
       updateCounts();
       updateFilterAvailability();
-      const initialSection = getCurrentSection() || 'cfop';
-      syncActiveFilterButtons(initialSection);
-      if (window.__DATA__[initialSection]) {
-        applyFilter(initialSection);
-      }
+      const initialSection = getSectionFromHash() || getCurrentSection() || 'guia';
+      switchSection(initialSection, false);
     }
 
     function setupEventListeners() {
@@ -2626,23 +2742,43 @@
           setActiveFilter(button, section, filter);
         }
       });
+
+      window.addEventListener('hashchange', function() {
+        const section = getSectionFromHash();
+        if (section) {
+          switchSection(section, false);
+        }
+      });
     }
 
-    function switchSection(sectionName) {
+    function getSectionFromHash() {
+      const section = window.location.hash.replace('#', '').trim();
+      return section && document.getElementById(section) && document.querySelector(`[data-section="${section}"]`) ? section : '';
+    }
+
+    function switchSection(sectionName, updateHash = true) {
+      const targetTab = document.querySelector(`[data-section="${sectionName}"]`);
+      const targetSection = document.getElementById(sectionName);
+      if (!targetTab || !targetSection) return;
+
       // Atualizar navegação
       document.querySelectorAll('.nav-tab').forEach(tab => {
         tab.classList.remove('active');
       });
-      document.querySelector(`[data-section="${sectionName}"]`).classList.add('active');
+      targetTab.classList.add('active');
 
       // Atualizar seções
       document.querySelectorAll('.section').forEach(section => {
         section.classList.remove('active');
       });
-      document.getElementById(sectionName).classList.add('active');
+      targetSection.classList.add('active');
 
       syncActiveFilterButtons(sectionName);
       applyFilter(sectionName);
+
+      if (updateHash && window.location.hash !== `#${sectionName}`) {
+        history.replaceState(null, '', `#${sectionName}`);
+      }
     }
 
     function renderSection(sectionName) {


### PR DESCRIPTION
## O que mudou

- Adiciona uma camada visual reutilizável para leitura guiada e callouts contextuais nos manuais HTML.
- Cria trilhas de continuidade entre manual fiscal, manual financeiro, guia DP/RH, compliance de transportadoras e painel fiscal.
- Atualiza o painel fiscal para aceitar links diretos por hash, abrindo a aba correta como `painel-fiscal/index.html#reforma`.
- Aplica atualizações pertinentes de 2026: NT 2025.002 v.1.35, Informe Técnico 2025.002 v.1.50/cClassTrib, NCM/uTrib vigente desde 01/02/2026, meios de pagamento de 06/03/2026, NT CT-e 2026.001 v.1.01 e Portaria SUROC nº 6/2026 da ANTT.

## Validação

- `git fetch --all --prune` confirmou `main` alinhada com `origin/main` antes da alteração.
- Link-check local confirmou arquivos e âncoras entre os cinco HTMLs.
- Parse dos scripts inline dos cinco HTMLs passou sem erro.
- Playwright headless abriu os cinco documentos e confirmou que `painel-fiscal/index.html#reforma` ativa a aba Reforma Tributária.